### PR TITLE
Neosemantics Setup Improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ data/
 logs/
 plugins/
 
+config.ini
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/docker/README.md
+++ b/docker/README.md
@@ -93,10 +93,16 @@ Follow these steps to set up Neo4j with Neosemantics and import your ontology.
 2. **Run the Initialization Command:**
 
    ```cypher
-   CALL n10s.graphconfig.init();
+   CALL n10s.graphconfig.init({ handleVocabUris: "IGNORE" });
    ```
 
    - **Expected Outcome:** A success message indicating that the graph configuration has been initialized.
+
+3. **Create constraint to ensure unique URIs on Resources:**
+
+   ```cypher
+   CREATE CONSTRAINT n10s_unique_uri FOR (r:Resource) REQUIRE r.uri IS UNIQUE;
+   ```
 
 ### 6. Import the Ontology
 


### PR DESCRIPTION
I did some research on the strange appearance of the `ns0__` prefixes on Nodes and Relationships.
According to the Neosemantics documentation the prefixes are applied dynamically in the sequence they appear. https://neo4j.com/labs/neosemantics/4.0/import/#actual-rdf-import

I found a way to ignore those prefixes by adding an argument to the n10s graphconfig init call:
```
CALL n10s.graphconfig.init({ handleVocabUris: "IGNORE" });
```
With that option enabled the example queries are working fine (see screenshot below).

Besides that I have also added the creation of the unique uri constraint to the Readme which previously led to an error.

In the `.gitignore` I added an entry for the `config.ini` to prevent accidental leakage of API keys.

![grafik](https://github.com/user-attachments/assets/c6b9e5ea-a616-413c-9bd3-e9e5bcb5fd3d)